### PR TITLE
feat: add game status verifier for end game (win and game over)

### DIFF
--- a/src/Game.hs
+++ b/src/Game.hs
@@ -42,9 +42,7 @@ demoBoardWin =
     [Tile 512, Tile 1024, Tile 1024, Empty],
     [Tile 1024, Tile 1024, Empty, Empty]
   ]
-
 -}
-
 
 emptyBoard :: Board
 emptyBoard = replicate size $ replicate size Empty
@@ -52,7 +50,7 @@ emptyBoard = replicate size $ replicate size Empty
 initialModel :: Model
 initialModel =
   Model
-    { board = emptyBoard, -- demoBoardWin,
+    { board = emptyBoard,
       score = initialScore,
       gameState = InProgress
     }

--- a/src/Game.hs
+++ b/src/Game.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE InstanceSigs #-}
 
-module Game (Tile (..), Board, Model (..), Action (..), initialModel, gameSubs) where
+module Game (Tile (..), Board, Model (..), Action (..), GameState (..), initialModel, gameSubs) where
 
 import Constants (initialScore, size)
 import Miso.Subscription.Keyboard (Arrows (..), directionSub)
@@ -11,16 +11,20 @@ data Tile
   | Tile Int
   deriving (Show, Eq)
 
+data GameState = InProgress | Win | GameOver
+  deriving (Show, Eq)
+
 type Board = [[Tile]]
 
 data Model = Model
   { board :: Board,
-    score :: Int
+    score :: Int,
+    gameState :: GameState
   }
 
 instance Eq Model where
   (==) :: Model -> Model -> Bool
-  (Model board1 score1) == (Model board2 score2) = board1 == board2 && score1 == score2
+  (Model board1 score1 gameState1) == (Model board2 score2 gameState2) = board1 == board2 && score1 == score2 && gameState1 == gameState2
 
 data Action
   = Initialize
@@ -30,12 +34,25 @@ data Action
 gameSubs :: [Sub Action]
 gameSubs = [directionSub ([38, 87], [40, 83], [37, 65], [39, 68]) ArrowPress]
 
+{-
+demoBoardWin :: Board
+demoBoardWin =
+  [ [Tile 2, Tile 4, Tile 8, Tile 16],
+    [Tile 32, Tile 64, Tile 128, Tile 256],
+    [Tile 512, Tile 1024, Tile 1024, Empty],
+    [Tile 1024, Tile 1024, Empty, Empty]
+  ]
+
+-}
+
+
 emptyBoard :: Board
 emptyBoard = replicate size $ replicate size Empty
 
 initialModel :: Model
 initialModel =
   Model
-    { board = emptyBoard,
-      score = initialScore
+    { board = emptyBoard, -- demoBoardWin,
+      score = initialScore,
+      gameState = InProgress
     }

--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -6,7 +6,7 @@ import Collision (collision)
 import Constants (size, tilesAmount, twoPercentChance)
 import Data.List (partition)
 import GHC.IO (unsafePerformIO)
-import Game (Action (..), Board, Model (..), Tile (..), GameState (..))
+import Game (Action (..), Board, GameState (..), Model (..), Tile (..))
 import Miso (Effect, noEff)
 import Miso.Subscription.Keyboard (Arrows (..))
 import Utils (chop, getRandomInt, getValueOfVectorIndex, transpose)
@@ -22,19 +22,17 @@ updateModel (ArrowPress Arrows {..}) Model {..} =
           else Model {board = finalBoard, score = score, gameState = checkGameState finalBoard}
    in noEff updatedModel
 
-
 checkGameState :: Board -> GameState
 checkGameState board
-  | any (any (== Tile 2048)) board = Win
-  | not (any (any (== Empty)) board) && not (canMerge board) = GameOver
+  | any (elem (Tile 2048)) board = Win
+  | not (any (elem Empty) board) && not (canMerge board) = GameOver
   | otherwise = InProgress
-
 
 canMerge :: Board -> Bool
 canMerge board = any canMergeRow board || any canMergeRow (transpose board)
 
 canMergeRow :: [Tile] -> Bool
-canMergeRow (x:y:xs) = x == y || canMergeRow (y:xs)
+canMergeRow (x : y : xs) = x == y || canMergeRow (y : xs)
 canMergeRow _ = False
 
 initBoard :: Board -> Board

--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -6,7 +6,7 @@ import Collision (collision)
 import Constants (size, tilesAmount, twoPercentChance)
 import Data.List (partition)
 import GHC.IO (unsafePerformIO)
-import Game (Action (..), Board, Model (..), Tile (..))
+import Game (Action (..), Board, Model (..), Tile (..), GameState (..))
 import Miso (Effect, noEff)
 import Miso.Subscription.Keyboard (Arrows (..))
 import Utils (chop, getRandomInt, getValueOfVectorIndex, transpose)
@@ -18,9 +18,24 @@ updateModel (ArrowPress Arrows {..}) Model {..} =
       finalBoard = collision newBoard (arrowX, arrowY)
       updatedModel =
         if board /= finalBoard
-          then Model {board = addRandomTile finalBoard, score = score}
-          else Model {board = finalBoard, score = score}
+          then Model {board = addRandomTile finalBoard, score = score, gameState = checkGameState finalBoard}
+          else Model {board = finalBoard, score = score, gameState = checkGameState finalBoard}
    in noEff updatedModel
+
+
+checkGameState :: Board -> GameState
+checkGameState board
+  | any (any (== Tile 2048)) board = Win
+  | not (any (any (== Empty)) board) && not (canMerge board) = GameOver
+  | otherwise = InProgress
+
+
+canMerge :: Board -> Bool
+canMerge board = any canMergeRow board || any canMergeRow (transpose board)
+
+canMergeRow :: [Tile] -> Bool
+canMergeRow (x:y:xs) = x == y || canMergeRow (y:xs)
+canMergeRow _ = False
 
 initBoard :: Board -> Board
 initBoard board

--- a/src/Rendering.hs
+++ b/src/Rendering.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE RecordWildCards #-}
+
 module Rendering (viewModel) where
 
 import Data.Map (fromList)
-import Game (Action (..), Model (..), Tile (..), GameState(..))
-import Miso (View, div_, button_, h1_, p_, span_, style_, text)
+import Game (Action (..), GameState (..), Model (..), Tile (..))
+import Miso (View, button_, div_, h1_, p_, span_, style_, text)
 import Miso.String (ms)
 
 viewModel :: Model -> View Action
@@ -42,7 +43,7 @@ viewModel Model {..} =
             (map viewTile (concat board)),
           case gameState of
             Win -> viewOverlay "074003" "WIN :D"
-            GameOver -> viewOverlay  "C93716" "GAME OVER"
+            GameOver -> viewOverlay "C93716" "GAME OVER"
             InProgress -> div_ [] []
         ],
       div_

--- a/src/Rendering.hs
+++ b/src/Rendering.hs
@@ -1,10 +1,9 @@
 {-# LANGUAGE RecordWildCards #-}
-
 module Rendering (viewModel) where
 
 import Data.Map (fromList)
-import Game (Action (..), Model (..), Tile (..))
-import Miso (View, button_, div_, h1_, p_, span_, style_, text)
+import Game (Action (..), Model (..), Tile (..), GameState(..))
+import Miso (View, div_, button_, h1_, p_, span_, style_, text)
 import Miso.String (ms)
 
 viewModel :: Model -> View Action
@@ -27,7 +26,8 @@ viewModel Model {..} =
                 (ms "padding", ms "10px"),
                 (ms "border-radius", ms "6px"),
                 (ms "width", ms "400px"),
-                (ms "margin-right", ms "40px")
+                (ms "margin-right", ms "40px"),
+                (ms "position", ms "relative")
               ]
         ]
         [ div_
@@ -39,7 +39,11 @@ viewModel Model {..} =
                     (ms "grid-gap", ms "10px")
                   ]
             ]
-            (map viewTile (concat board))
+            (map viewTile (concat board)),
+          case gameState of
+            Win -> viewOverlay "074003" "WIN :D"
+            GameOver -> viewOverlay  "C93716" "GAME OVER"
+            InProgress -> div_ [] []
         ],
       div_
         [ style_ $
@@ -162,6 +166,34 @@ viewModel Model {..} =
             ]
             [text $ ms "New Game"]
         ]
+    ]
+
+viewOverlay :: String -> String -> View Action
+viewOverlay color message =
+  div_
+    [ style_ $
+        fromList
+          [ (ms "position", ms "absolute"),
+            (ms "top", ms "0"),
+            (ms "left", ms "0"),
+            (ms "width", ms "100%"),
+            (ms "height", ms "100%"),
+            (ms "background", ms $ "#" ++ color ++ "A6"),
+            (ms "display", ms "flex"),
+            (ms "justify-content", ms "center"),
+            (ms "align-items", ms "center")
+          ]
+    ]
+    [ div_
+        [ style_ $
+            fromList
+              [ (ms "padding", ms "10px 20px"),
+                (ms "color", ms "#ffffff"),
+                (ms "font-size", ms "30px"),
+                (ms "font-weight", ms "bold")
+              ]
+        ]
+        [text $ ms message]
     ]
 
 viewTile :: Tile -> View Action


### PR DESCRIPTION
This Pull Request adds functionality to verify win and game over conditions in the 2048 game, It introduces checks for win condition when the player achieves the 2048 tile and for game over when there are no valid moves left,  updating the UI depending on the game state

## Changes Made

- Added functions to verify win and game over conditions.
- Integrated these functions into the game logic to trigger appropriate messages or actions when win or game over conditions are met.
- Added functions to edit the style of the view depending the game state.

## Checklist

- [x] Implemented win condition check.
- [x] Implemented game over condition check.
- [x] Integrated win and game over checks into game logic.
- [x] Integrated win and game over checks for updating the UI (view).

**Game over View**

![Game Over View](https://github.com/MorveN11/final-project-programming-v/assets/82351290/7ba005bd-9050-4385-8fd1-26f899b58a20)


**Win View**


![Win View](https://github.com/MorveN11/final-project-programming-v/assets/82351290/bcdcc99e-6578-4a07-9c3d-2fe0d964049b)
